### PR TITLE
chore: add mainnet emergency upgrades

### DIFF
--- a/pages/network/upgrades.mdx
+++ b/pages/network/upgrades.mdx
@@ -4,12 +4,12 @@
 
 | Tag                                                                   | Name                             | Start Height                                            | Notes 
 |-----------------------------------------------------------------------|----------------------------------|---------------------------------------------------------|--------------------------------------------------------------|
-| [`v1.0.0`](https://github.com/noble-assets/noble/releases/tag/v1.0.0) |                                  | [0](https://www.mintscan.io/noble/blocks/1)             | Genesis version
+| [`v1.0.0`](https://github.com/noble-assets/noble/releases/tag/v1.0.0) |                                  | [0](https://www.mintscan.io/noble/blocks/1)             | Genesis Version
 | [`v2.0.0`](https://github.com/noble-assets/noble/releases/tag/v2.0.0) | [Neon](/network/upgrades/neon)   | [119000](https://www.mintscan.io/noble/blocks/119000)   |
 | [`v3.0.0`](https://github.com/noble-assets/noble/releases/tag/v3.0.0) | [Radon](/network/upgrades/radon) | [1296000](https://www.mintscan.io/noble/blocks/1296000) |
 | [`v3.1.0`](https://github.com/noble-assets/noble/releases/tag/v3.1.0) | v3.1.0                           | [2672000](https://www.mintscan.io/noble/block/2672000)  |
 | [`v4.0.2`](https://github.com/noble-assets/noble/releases/tag/v4.0.2) | [Argon](/network/upgrades/argon) | [3408600](https://www.mintscan.io/noble/block/3377500)  | must set `--halt-height 5262000` to upgrade to next version
 | [`v4.0.3`](https://github.com/noble-assets/noble/releases/tag/v4.0.3) |                                  | [5262000](https://www.mintscan.io/noble/block/5262000)  | 
-| [`v4.1.1`](https://github.com/noble-assets/noble/releases/tag/v4.1.1) | Fusion                           | [5797500](https://www.mintscan.io/noble/block/5797500)  | must set: `--halt-height 6022000` to upgrade to next version
-| [`v4.1.2`](https://github.com/noble-assets/noble/releases/tag/v4.1.2) |                                  | [6022000](https://www.mintscan.io/noble/block/5797500)  | must set: `--halt-height 6139500` to upgrade to next version
+| [`v4.1.1`](https://github.com/noble-assets/noble/releases/tag/v4.1.1) | Fusion                           | [5797500](https://www.mintscan.io/noble/block/5797500)  | must set `--halt-height 6022000` to upgrade to next version
+| [`v4.1.2`](https://github.com/noble-assets/noble/releases/tag/v4.1.2) |                                  | [6022000](https://www.mintscan.io/noble/block/5797500)  | must set `--halt-height 6139500` to upgrade to next version
 | [`v4.1.3`](https://github.com/noble-assets/noble/releases/tag/v4.1.3) |                                  | [6139500](https://www.mintscan.io/noble/block/5797500)  | 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Updated versions (`v4.1.2` and `v4.1.3`) with start heights and upgrade instructions for Noble network upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->