### PR TITLE
docs: fix broken link and add CCTP contract addresses

### DIFF
--- a/pages/cctp/contract_addresses.mdx
+++ b/pages/cctp/contract_addresses.mdx
@@ -2,18 +2,22 @@
 
 ## Mainnet
 
-| Chain     | Domain | Address |
-| :-------- | :----: | ------: |
-| Ethereum  |   0    | [0xbd3fa81b58ba92a82136038b25adec7066af3155](https://etherscan.io/address/0xbd3fa81b58ba92a82136038b25adec7066af3155) |
-| Avalanche |   1    | [0x6b25532e1060ce10cc3b0a99e5683b91bfde6982](https://snowtrace.io/address/0x6b25532e1060ce10cc3b0a99e5683b91bfde6982) |
-| OP Mainnet|   2    | [0x2B4069517957735bE00ceE0fadAE88a26365528f](https://optimistic.etherscan.io/address/0x2b4069517957735be00cee0fadae88a26365528f) |
-| Arbitrum  |   3    | [0x19330d10D9Cc8751218eaf51E8885D058642E08A](https://arbiscan.io/address/0x19330d10D9Cc8751218eaf51E8885D058642E08A) |
+| Chain        | Domain | Address |
+| :--------    | :----: | ------: |
+| Ethereum     |   0    | [0xbd3fa81b58ba92a82136038b25adec7066af3155](https://etherscan.io/address/0xbd3fa81b58ba92a82136038b25adec7066af3155)            |
+| Avalanche    |   1    | [0x6b25532e1060ce10cc3b0a99e5683b91bfde6982](https://snowtrace.io/address/0x6b25532e1060ce10cc3b0a99e5683b91bfde6982)            |
+| OP Mainnet   |   2    | [0x2B4069517957735bE00ceE0fadAE88a26365528f](https://optimistic.etherscan.io/address/0x2b4069517957735be00cee0fadae88a26365528f) |
+| Arbitrum     |   3    | [0x19330d10D9Cc8751218eaf51E8885D058642E08A](https://arbiscan.io/address/0x19330d10D9Cc8751218eaf51E8885D058642E08A)             |
+| Base         |   6    | [0x1682Ae6375C4E4A97e4B583BC394c861A46D8962](https://basescan.org/address/0x1682Ae6375C4E4A97e4B583BC394c861A46D8962)            |
+| Polygon PoS  |   7    | [0x9daF8c91AEFAE50b9c0E69629D3F6Ca40cA3B3FE](https://polygonscan.com/address/0x9daf8c91aefae50b9c0e69629d3f6ca40ca3b3fe)         |
+| Unichain     |   10   | [0x4e744b28E787c3aD0e810eD65A24461D4ac5a762](https://uniscan.xyz/address/0x4e744b28E787c3aD0e810eD65A24461D4ac5a762)             |
+
 
 ## Testnet
 
-| Chain     | Domain |                                                                                                                            Address |
-| :-------- | :----: | ---------------------------------------------------------------------------------------------------------------------------------: |
-| Ethereum  |   0    |       [0x1ae045d99236365cbdc1855acd2d2cfc232d04d1](https://goerli.etherscan.io/address/0x1ae045d99236365cbdc1855acd2d2cfc232d04d1) |
-| Avalanche |   1    | [0x7B66B923F808193a157E1b38Ef8C3AE8a97ACe98](https://testnet.snowtrace.io/address/0x7b66b923f808193a157e1b38ef8c3ae8a97ace98#code) |
-| OP Mainnet|   2    |                                                                                         0x7B66B923F808193a157E1b38Ef8C3AE8a97ACe98 |
-| Arbitrum  |   3    |                                                                                         0x7B66B923F808193a157E1b38Ef8C3AE8a97ACe98 |
+| Chain             | Domain | Address |                                                                                         
+| :--------         | :----: | ------: |
+| Ethereum Sepolia  |   0    | [0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5](https://sepolia.etherscan.io/address/0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5)          |
+| Avalanche Fuji    |   1    | [0xeb08f243E5d3FCFF26A9E38Ae5520A669f4019d0](https://testnet.snowtrace.io/address/0xeb08f243e5d3fcff26a9e38ae5520a669f4019d0)          |
+| OP Sepolia        |   2    | [0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5](https://sepolia-optimism.etherscan.io/address/0x9f3b8679c73c2fef8b59b4f3444d4e156fb70aa5) |  
+| Arbitrum Sepolia  |   3    | [0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5](https://sepolia.arbiscan.io/address/0x9f3b8679c73c2fef8b59b4f3444d4e156fb70aa5)           |

--- a/pages/cctp/contract_addresses.mdx
+++ b/pages/cctp/contract_addresses.mdx
@@ -1,17 +1,13 @@
 # CCTP Contract Addresses
 
-import { Callout } from "nextra/components";
-
 ## Mainnet
-
-<Callout emoji={"🚧"}>Coming Soon!</Callout>
 
 | Chain     | Domain | Address |
 | :-------- | :----: | ------: |
-| Ethereum  |   0    |         |
-| Avalanche |   1    |         |
-| Optimism  |   2    |         |
-| Arbitrum  |   3    |         |
+| Ethereum  |   0    | 0xbd3fa81b58ba92a82136038b25adec7066af3155 |
+| Avalanche |   1    | 0x6b25532e1060ce10cc3b0a99e5683b91bfde6982 |
+| OP Mainnet|   2    | 0x2B4069517957735bE00ceE0fadAE88a26365528f |
+| Arbitrum  |   3    | 0x19330d10D9Cc8751218eaf51E8885D058642E08A |
 
 ## Testnet
 
@@ -19,5 +15,5 @@ import { Callout } from "nextra/components";
 | :-------- | :----: | ---------------------------------------------------------------------------------------------------------------------------------: |
 | Ethereum  |   0    |       [0x1ae045d99236365cbdc1855acd2d2cfc232d04d1](https://goerli.etherscan.io/address/0x1ae045d99236365cbdc1855acd2d2cfc232d04d1) |
 | Avalanche |   1    | [0x7B66B923F808193a157E1b38Ef8C3AE8a97ACe98](https://testnet.snowtrace.io/address/0x7b66b923f808193a157e1b38ef8c3ae8a97ace98#code) |
-| Optimism  |   2    |                                                                                         0x7B66B923F808193a157E1b38Ef8C3AE8a97ACe98 |
+| OP Mainnet|   2    |                                                                                         0x7B66B923F808193a157E1b38Ef8C3AE8a97ACe98 |
 | Arbitrum  |   3    |                                                                                         0x7B66B923F808193a157E1b38Ef8C3AE8a97ACe98 |

--- a/pages/cctp/contract_addresses.mdx
+++ b/pages/cctp/contract_addresses.mdx
@@ -4,10 +4,10 @@
 
 | Chain     | Domain | Address |
 | :-------- | :----: | ------: |
-| Ethereum  |   0    | 0xbd3fa81b58ba92a82136038b25adec7066af3155 |
-| Avalanche |   1    | 0x6b25532e1060ce10cc3b0a99e5683b91bfde6982 |
-| OP Mainnet|   2    | 0x2B4069517957735bE00ceE0fadAE88a26365528f |
-| Arbitrum  |   3    | 0x19330d10D9Cc8751218eaf51E8885D058642E08A |
+| Ethereum  |   0    | [0xbd3fa81b58ba92a82136038b25adec7066af3155](https://etherscan.io/address/0xbd3fa81b58ba92a82136038b25adec7066af3155) |
+| Avalanche |   1    | [0x6b25532e1060ce10cc3b0a99e5683b91bfde6982](https://snowtrace.io/address/0x6b25532e1060ce10cc3b0a99e5683b91bfde6982) |
+| OP Mainnet|   2    | [0x2B4069517957735bE00ceE0fadAE88a26365528f](https://optimistic.etherscan.io/address/0x2b4069517957735be00cee0fadae88a26365528f) |
+| Arbitrum  |   3    | [0x19330d10D9Cc8751218eaf51E8885D058642E08A](https://arbiscan.io/address/0x19330d10D9Cc8751218eaf51E8885D058642E08A) |
 
 ## Testnet
 

--- a/pages/cctp/contract_addresses.mdx
+++ b/pages/cctp/contract_addresses.mdx
@@ -4,20 +4,29 @@
 
 | Chain        | Domain | Address |
 | :--------    | :----: | ------: |
-| Ethereum     |   0    | [0xbd3fa81b58ba92a82136038b25adec7066af3155](https://etherscan.io/address/0xbd3fa81b58ba92a82136038b25adec7066af3155)            |
-| Avalanche    |   1    | [0x6b25532e1060ce10cc3b0a99e5683b91bfde6982](https://snowtrace.io/address/0x6b25532e1060ce10cc3b0a99e5683b91bfde6982)            |
-| OP Mainnet   |   2    | [0x2B4069517957735bE00ceE0fadAE88a26365528f](https://optimistic.etherscan.io/address/0x2b4069517957735be00cee0fadae88a26365528f) |
-| Arbitrum     |   3    | [0x19330d10D9Cc8751218eaf51E8885D058642E08A](https://arbiscan.io/address/0x19330d10D9Cc8751218eaf51E8885D058642E08A)             |
-| Base         |   6    | [0x1682Ae6375C4E4A97e4B583BC394c861A46D8962](https://basescan.org/address/0x1682Ae6375C4E4A97e4B583BC394c861A46D8962)            |
-| Polygon PoS  |   7    | [0x9daF8c91AEFAE50b9c0E69629D3F6Ca40cA3B3FE](https://polygonscan.com/address/0x9daf8c91aefae50b9c0e69629d3f6ca40ca3b3fe)         |
-| Unichain     |   10   | [0x4e744b28E787c3aD0e810eD65A24461D4ac5a762](https://uniscan.xyz/address/0x4e744b28E787c3aD0e810eD65A24461D4ac5a762)             |
+| Ethereum     |   0    | [0xbd3fa81b58ba92a82136038b25adec7066af3155](https://etherscan.io/address/0xbd3fa81b58ba92a82136038b25adec7066af3155)                                                                                        |
+| Avalanche    |   1    | [0x6b25532e1060ce10cc3b0a99e5683b91bfde6982](https://snowtrace.io/address/0x6b25532e1060ce10cc3b0a99e5683b91bfde6982)                                                                                        |
+| OP Mainnet   |   2    | [0x2B4069517957735bE00ceE0fadAE88a26365528f](https://optimistic.etherscan.io/address/0x2b4069517957735be00cee0fadae88a26365528f)                                                                             |
+| Arbitrum     |   3    | [0x19330d10D9Cc8751218eaf51E8885D058642E08A](https://arbiscan.io/address/0x19330d10D9Cc8751218eaf51E8885D058642E08A)                                                                                         |
+| Solana       |   5    | [CCTPiPYPc6AsJuwueEnWgSgucamXDZwBd53dQ11YiKX3](https://solscan.io/account/CCTPiPYPc6AsJuwueEnWgSgucamXDZwBd53dQ11YiKX3)                                                                                      |
+| Base         |   6    | [0x1682Ae6375C4E4A97e4B583BC394c861A46D8962](https://basescan.org/address/0x1682Ae6375C4E4A97e4B583BC394c861A46D8962)                                                                                        |
+| Polygon PoS  |   7    | [0x9daF8c91AEFAE50b9c0E69629D3F6Ca40cA3B3FE](https://polygonscan.com/address/0x9daf8c91aefae50b9c0e69629d3f6ca40ca3b3fe)                                                                                     |
+| Sui          |   8    | [0x2aa6c5d56376c371f88a6cc42e852824994993cb9bab8d3e6450cbe3cb32b94e](https://suiscan.xyz/mainnet/object/0x2aa6c5d56376c371f88a6cc42e852824994993cb9bab8d3e6450cbe3cb32b94e/tx-blocks)                        |
+| Aptos        |   9    | [0x9bce6734f7b63e835108e3bd8c36743d4709fe435f44791918801d0989640a9d](https://explorer.aptoslabs.com/account/0x9bce6734f7b63e835108e3bd8c36743d4709fe435f44791918801d0989640a9d/transactions?network=mainnet) |
+| Unichain     |  10    | [0x4e744b28E787c3aD0e810eD65A24461D4ac5a762](https://uniscan.xyz/address/0x4e744b28E787c3aD0e810eD65A24461D4ac5a762)                                                                                         |
 
 
 ## Testnet
 
 | Chain             | Domain | Address |                                                                                         
 | :--------         | :----: | ------: |
-| Ethereum Sepolia  |   0    | [0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5](https://sepolia.etherscan.io/address/0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5)          |
-| Avalanche Fuji    |   1    | [0xeb08f243E5d3FCFF26A9E38Ae5520A669f4019d0](https://testnet.snowtrace.io/address/0xeb08f243e5d3fcff26a9e38ae5520a669f4019d0)          |
-| OP Sepolia        |   2    | [0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5](https://sepolia-optimism.etherscan.io/address/0x9f3b8679c73c2fef8b59b4f3444d4e156fb70aa5) |  
-| Arbitrum Sepolia  |   3    | [0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5](https://sepolia.arbiscan.io/address/0x9f3b8679c73c2fef8b59b4f3444d4e156fb70aa5)           |
+| Ethereum Sepolia  |   0    | [0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5](https://sepolia.etherscan.io/address/0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5)             |
+| Avalanche Fuji    |   1    | [0xeb08f243E5d3FCFF26A9E38Ae5520A669f4019d0](https://testnet.snowtrace.io/address/0xeb08f243e5d3fcff26a9e38ae5520a669f4019d0)             |
+| OP Sepolia        |   2    | [0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5](https://sepolia-optimism.etherscan.io/address/0x9f3b8679c73c2fef8b59b4f3444d4e156fb70aa5)    |   
+| Arbitrum Sepolia  |   3    | [0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5](https://sepolia.arbiscan.io/address/0x9f3b8679c73c2fef8b59b4f3444d4e156fb70aa5)              |
+| Solana Devnet     |   5    | [CCTPiPYPc6AsJuwueEnWgSgucamXDZwBd53dQ11YiKX3](https://solscan.io/account/CCTPiPYPc6AsJuwueEnWgSgucamXDZwBd53dQ11YiKX3)                   |
+| Base Sepolia      |   6    | [0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5](https://base-sepolia.blockscout.com/address/0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5)      |
+| Polygon PoS Amoy  |   7    | [0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5](https://www.oklink.com/amoy/address/0x9f3b8679c73c2fef8b59b4f3444d4e156fb70aa5)              |
+| Sui Testnet       |   8    | 0x31cc14d80c175ae39777c0238f20594c6d4869cfab199f40b69f3319956b8beb                                                                        |
+| Aptos Testnet     |   9    | 0x5f9b937419dda90aa06c1836b7847f65bbbe3f1217567758dc2488be31a477b9                                                                        |
+| Unichain Sepolia  |   10   | [0x8ed94B8dAd2Dc5453862ea5e316A8e71AAed9782](https://unichain-sepolia.blockscout.com/address/0x8ed94B8dAd2Dc5453862ea5e316A8e71AAed9782)  |

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -8,7 +8,7 @@
 
 ## Noble Design
 
-The Noble blockchain conforms to [industry standard]((https://github.com/centrehq/centre-tokens/blob/master/doc/tokendesign.md) smart contracting capabilities with regards to asset issuance functionality. This functionality allows the minting and burning of tokens by multiple entities and the freezing and blacklisting of addresses on the Noble chain.
+The Noble blockchain conforms to [industry standard](https://github.com/centrehq/centre-tokens/blob/master/doc/tokendesign.md) smart contracting capabilities with regards to asset issuance functionality. This functionality allows the minting and burning of tokens by multiple entities and the freezing and blacklisting of addresses on the Noble chain.
 
 ## Security Guarantees of Validator Set
 


### PR DESCRIPTION
fixes a formatting issue in a markdown link and adds CCTP contract addresses to`contract_addresses.mdx`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Replaced placeholder messaging with populated contract-address tables for Mainnet and Testnet, listing networks, domain identifiers, and explorer links.
  - Expanded Testnet coverage with Sepolia-based entries and additional testnets (Solana Devnet, Base Sepolia, Polygon Amoy, Sui Testnet, Aptos Testnet, Unichain Sepolia).
  - Fixed a broken hyperlink in the Noble Design section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->