### PR TITLE
docs: fix broken links to Circle's docs

### DIFF
--- a/pages/cctp/index.mdx
+++ b/pages/cctp/index.mdx
@@ -13,4 +13,4 @@ The simple transfer flow is the same for every source/destination chain route:
 
 ![](./cctp-high-level.png)
 
-[Cross-Chain Transfer Protocol]: https://developers.circle.com/stablecoin/docs/cctp-getting-started
+[Cross-Chain Transfer Protocol]: https://developers.circle.com/stablecoins/cctp-getting-started

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -8,7 +8,7 @@
 
 ## Noble Design
 
-The Noble blockchain conforms to [industry standard]((https://github.com/centrehq/centre-tokens/blob/master/doc/tokendesign.md) smart contracting capabilities with regards to asset issuance functionality. This functionality allows the minting and burning of tokens by multiple entities and the freezing and blacklisting of addresses on the Noble chain.
+The Noble blockchain conforms to [industry standard](https://github.com/circlefin/stablecoin-evm/blob/master/doc/tokendesign.md) smart contracting capabilities with regards to asset issuance functionality. This functionality allows the minting and burning of tokens by multiple entities and the freezing and blacklisting of addresses on the Noble chain.
 
 ## Security Guarantees of Validator Set
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the URL for the Cross-Chain Transfer Protocol reference to direct users to the new resource.
  - Revised the hyperlink in the Noble blockchain description to point to the updated documentation on Circle's repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->