### PR TITLE
chore: add option to manually deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,47 +1,48 @@
-# name: Deploy to GitHub Pages
-# 
-# on:
-#   push:
-#     branches:
-#       - main
-# 
-# jobs:
-#   build:
-#     name: Build Docusaurus
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v4
-#         with:
-#           fetch-depth: 0
-#       - uses: actions/setup-node@v4
-#         with:
-#           node-version: 18
-#           cache: yarn
-# 
-#       - name: Install dependencies
-#         run: yarn install --frozen-lockfile
-#       - name: Build website
-#         run: yarn build
-# 
-#       - name: Upload Build Artifact
-#         uses: actions/upload-pages-artifact@v3
-#         with:
-#           path: build
-# 
-#   deploy:
-#     name: Deploy to GitHub Pages
-#     needs: build
-# 
-#     permissions:
-#       pages: write
-#       id-token: write
-# 
-#     environment:
-#       name: github-pages
-#       url: ${{ steps.deployment.outputs.page_url }}
-# 
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Deploy to GitHub Pages
-#         id: deployment
-#         uses: actions/deploy-pages@v4
+name: Deploy to GitHub Pages
+
+on:
+  # push:
+  #   branches:
+  #     - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Docusaurus
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Build website
+        run: yarn build
+
+      - name: Upload Build Artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,12 +11,12 @@ jobs:
     name: Build Docusaurus
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 24
           cache: yarn
 
       - name: Install dependencies

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -10,12 +10,12 @@ jobs:
     name: Test deployment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 24
           cache: yarn
 
       - name: Install dependencies


### PR DESCRIPTION
This PR uncomments the docs deployment workflow but only to be triggered manually when we decide it's time for an update whilst changes are ongoing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment workflow changed to manual trigger (on-demand) instead of automatic pushes to main.
  * CI toolchain updated (action/runtime versions upgraded and Node.js runtime bumped) for improved build environment.
  * Build and publish behavior unchanged — site still compiled and published to Pages with existing settings.
  * No user-facing functionality changes; releases are now initiated manually.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->