### PR TITLE
fix: testnet upgrade tag

### DIFF
--- a/docs/build/chain-upgrades/testnet.mdx
+++ b/docs/build/chain-upgrades/testnet.mdx
@@ -19,7 +19,7 @@ sidebar_position: 2
 | Tag                                                                             | Name       | Start Height                                                       | Notes 
 |---------------------------------------------------------------------------------|------------|--------------------------------------------------------------------|----------------|
 | [`v9.0.0-rc.3`](https://github.com/noble-assets/noble/releases/tag/v9.0.0-rc.3) |            | [24114000](https://www.mintscan.io/noble-testnet/block/24114000)   |           |
-| [`v10.0.0-beta.0`](https://github.com/noble-assets/noble/releases/tag/v10.0.0-beta.0) | stratum  | [29035000](https://www.mintscan.io/noble-testnet/block/29035000)   |           |
+| [`v10.0.0-beta.1`](https://github.com/noble-assets/noble/releases/tag/v10.0.0-beta.1) | stratum  | [29035000](https://www.mintscan.io/noble-testnet/block/29035000)   |           |
 | [`v10.0.0-rc.2`](https://github.com/noble-assets/noble/releases/tag/v10.0.0-rc.2) | stratum | [30385000](https://www.mintscan.io/noble-testnet/block/30385000)   |           |
 | [`v10.0.0-rc.3`](https://github.com/noble-assets/noble/releases/tag/v10.0.0-rc.3) | stratum | [31525000](https://www.mintscan.io/noble-testnet/block/31525000)   | must set `--halt-height 33800000` to upgrade to next version |
 | [`v10.0.1`](https://github.com/noble-assets/noble/releases/tag/v10.0.1) |            | [33800000](https://www.mintscan.io/noble-testnet/block/33800000)   | |


### PR DESCRIPTION
`v10.0.0-beta.0` has a typo in the upgrade name, this should be `v10.0.0-beta.1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated testnet chain upgrade documentation with the latest release version reference. The upgrade information table now reflects the current beta release tag, providing developers with accurate version information needed for testnet chain upgrades and ensuring smooth deployment execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->